### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/MiguelElGallo/mpzsql/security/code-scanning/1](https://github.com/MiguelElGallo/mpzsql/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow primarily checks out code, installs dependencies, runs tests, and uploads coverage to Codecov (an external service), it typically only requires `contents: read` permission. This permission setting should be added at the workflow or job level. The minimal fix is to add `permissions: contents: read` at the top level, just after the `name:` and before the `on:` block, so it applies to all jobs. No additional dependencies or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
