### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_flightsql_protobuf_comprehensive.py
+++ b/tests/test_flightsql_protobuf_comprehensive.py
@@ -9,7 +9,7 @@ import pytest
 from unittest.mock import patch
 import pyarrow as pa
 from google.protobuf import any_pb2
-
+from urllib.parse import urlparse
 from mpzsql.flightsql.protobuf import (
     FlightSQLProtobuf,
     parse_any_command,
@@ -556,7 +556,9 @@ class TestFlightSQLProtobufComprehensive:
             assert hasattr(self.protobuf, constant_name)
             value = getattr(self.protobuf, constant_name)
             assert isinstance(value, str)
-            assert "type.googleapis.com" in value
+            # Ensure host is exactly 'type.googleapis.com'
+            parsed_url = urlparse(value)
+            assert parsed_url.netloc == "type.googleapis.com"
             assert "arrow.flight.protocol.sql" in value
     
     # ===============================


### PR DESCRIPTION
Potential fix for [https://github.com/MiguelElGallo/mpzsql/security/code-scanning/3](https://github.com/MiguelElGallo/mpzsql/security/code-scanning/3)

To fix the problem, we should avoid checking for the presence of "type.googleapis.com" using substring matching. Instead, we should parse the value as a URL and check that the host portion matches "type.googleapis.com" exactly. In Python, the `urllib.parse` module's `urlparse` function can be used to extract the host from the URL. If the value is of the form "type.googleapis.com/arrow.flight.protocol.sql.CommandStatementQuery", the host should be "type.googleapis.com". The fix is to replace the substring check with a proper host check using `urlparse`.

This change should be made in the test method `test_type_url_constants_completeness` in file `tests/test_flightsql_protobuf_comprehensive.py`, specifically for the line `assert "type.googleapis.com" in value`.  
We'll need to import `urlparse` from `urllib.parse` at the top of the file (if not already present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
