### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_flightsql_protobuf.py
+++ b/tests/test_flightsql_protobuf.py
@@ -125,7 +125,8 @@ class TestFlightSQLProtobufBasedOnLogs:
             assert hasattr(self.protobuf, url_constant)
             url_value = getattr(self.protobuf, url_constant)
             assert isinstance(url_value, str)
-            assert urlparse(url_value).hostname == "type.googleapis.com"
+            parsed_url = urlparse(url_value)
+            assert parsed_url.hostname == "type.googleapis.com"
 
     def test_action_type_urls_constants(self):
         """Test that action type URLs are defined."""

--- a/tests/test_flightsql_protobuf.py
+++ b/tests/test_flightsql_protobuf.py
@@ -8,7 +8,7 @@ testing the protobuf parsing, command creation, and schema generation functional
 import pytest
 from unittest.mock import patch
 import pyarrow as pa
-
+from urllib.parse import urlparse
 from mpzsql.flightsql.protobuf import FlightSQLProtobuf
 
 
@@ -125,7 +125,7 @@ class TestFlightSQLProtobufBasedOnLogs:
             assert hasattr(self.protobuf, url_constant)
             url_value = getattr(self.protobuf, url_constant)
             assert isinstance(url_value, str)
-            assert "type.googleapis.com" in url_value
+            assert urlparse(url_value).hostname == "type.googleapis.com"
 
     def test_action_type_urls_constants(self):
         """Test that action type URLs are defined."""

--- a/tests/test_flightsql_protobuf.py
+++ b/tests/test_flightsql_protobuf.py
@@ -126,6 +126,7 @@ class TestFlightSQLProtobufBasedOnLogs:
             url_value = getattr(self.protobuf, url_constant)
             assert isinstance(url_value, str)
             parsed_url = urlparse(url_value)
+            assert parsed_url.hostname is not None, f"Malformed URL: {url_value}"
             assert parsed_url.hostname == "type.googleapis.com"
 
     def test_action_type_urls_constants(self):


### PR DESCRIPTION
Potential fix for [https://github.com/MiguelElGallo/mpzsql/security/code-scanning/2](https://github.com/MiguelElGallo/mpzsql/security/code-scanning/2)

To fix the problem, the code should parse the URL and check that the host component is exactly `type.googleapis.com`, rather than relying on substring matching. This can be done by importing `urlparse` from Python's `urllib.parse` and using it to extract the host from each URL value before asserting its correctness. The change should be made within the `test_command_type_urls_constants` method in `tests/test_flightsql_protobuf.py`, replacing the substring check with a robust host check. This requires adding the import for `urlparse` (if not already present in the file) and updating the assertion on line 128 to use `urlparse(url_value).hostname == "type.googleapis.com"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
