### PR TITLE
Add error handling for race conditions in PostgreSQL database creation

### DIFF
--- a/src/mpzsql/cli.py
+++ b/src/mpzsql/cli.py
@@ -6,6 +6,7 @@ for the MPZSQL server, supporting all options from the original Examples impleme
 """
 import subprocess
 import psycopg2
+import psycopg2.errors
 import asyncio
 import logging
 import os
@@ -312,10 +313,15 @@ def ensure_postgresql_database(config: ServerConfig) -> bool:
             console.print(f"[green]✅ Database '{config.postgresql_catalogdb}' already exists[/green]")
             logger.info("PostgreSQL database already exists", database=config.postgresql_catalogdb)
         else:
-            # Create the database
-            cursor.execute(f'CREATE DATABASE "{config.postgresql_catalogdb}";')
-            console.print(f"[green]✅ Database '{config.postgresql_catalogdb}' created successfully[/green]")
-            logger.info("PostgreSQL database created", database=config.postgresql_catalogdb)
+            # Create the database with error handling for race conditions
+            try:
+                cursor.execute(f'CREATE DATABASE "{config.postgresql_catalogdb}";')
+                console.print(f"[green]✅ Database '{config.postgresql_catalogdb}' created successfully[/green]")
+                logger.info("PostgreSQL database created", database=config.postgresql_catalogdb)
+            except psycopg2.errors.DuplicateDatabase:
+                # Database was created by another process between our check and creation attempt
+                console.print(f"[green]✅ Database '{config.postgresql_catalogdb}' already exists (created concurrently)[/green]")
+                logger.info("PostgreSQL database already exists (created concurrently)", database=config.postgresql_catalogdb)
 
         cursor.close()
         conn.close()


### PR DESCRIPTION
This pull request improves error handling in the `ensure_postgresql_database` function to address potential race conditions during database creation. It also includes a minor import adjustment.

### Error handling improvements:

* [`src/mpzsql/cli.py`](diffhunk://#diff-7a080461c73708935dbf79933a8002969db81d7a7ba474776baf858dbc7ff8e8L315-R324): Enhanced the `ensure_postgresql_database` function to handle `psycopg2.errors.DuplicateDatabase` exceptions. This ensures that if the database is created by another process between the existence check and the creation attempt, the operation proceeds gracefully without errors.

### Import adjustment:

* [`src/mpzsql/cli.py`](diffhunk://#diff-7a080461c73708935dbf79933a8002969db81d7a7ba474776baf858dbc7ff8e8R9): Added the `psycopg2.errors` module to the imports to support the new error handling logic.