### PR TITLE
get_flight_info: New PATH branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "logfire>=3.24.0",
     "pytest-cov>=6.2.1",
     "grpcio-tools>=1.74.0",
+    "snowflake>=1.7.0",
 ]
 
 [project.scripts]

--- a/src/mpzsql/flightsql/minimal.py
+++ b/src/mpzsql/flightsql/minimal.py
@@ -18,6 +18,15 @@ from typing import Any, Dict, Iterator, List, Optional
 import pyarrow as pa
 import pyarrow.flight as pf  # keep original alias for pf.<...>
 
+from ..logfire_config import get_actions_logger, get_routing_logger
+
+# We now have both aliases available
+from ..security import (
+    BearerAuthServerMiddlewareFactory,
+    HeaderAuthServerMiddlewareFactory,
+    NoOpAuthHandler,
+    TLSCertificateLoader,
+)
 from .protobuf import (
     ActionBeginTransactionRequest,
     ActionClosePreparedStatementRequest,
@@ -36,15 +45,6 @@ from .protobuf import (
     DoPutUpdateResult,
     FlightSQLProtobuf,
     parse_any_command,
-)
-from ..logfire_config import get_actions_logger, get_routing_logger
-
-# We now have both aliases available
-from ..security import (
-    BearerAuthServerMiddlewareFactory,
-    HeaderAuthServerMiddlewareFactory,
-    NoOpAuthHandler,
-    TLSCertificateLoader,
 )
 
 # Initialize logfire loggers
@@ -262,7 +262,9 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
             pf.ActionType("BeginTransaction", "Begin a transaction"),
             pf.ActionType("EndTransaction", "End a transaction"),
             # Add session management actions (FlightSQL standard)
-            pf.ActionType("CloseSession", "Close and invalidate the current session context"),
+            pf.ActionType(
+                "CloseSession", "Close and invalidate the current session context"
+            ),
         ]
         return iter(actions)
 
@@ -371,52 +373,60 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
         try:
             # CloseSession typically receives no parameters (0 bytes as seen in logs)
             # This is a session cleanup action as per FlightSQL specification
-            
+
             logger.info("Closing session")
             print("SERVER: Closing session")
-            
+
             # Log session closure for actions.log
             actions_log.info("2. Command arguments: (none - session cleanup)")
             actions_log.info("3. Command sent to backend: session cleanup")
-            
+
             with self._mutex:
                 # Clean up any session-specific state
                 # For a stateless server, this is mostly a no-op, but we can:
                 # 1. Clean up any remaining prepared statements (defensive cleanup)
                 # 2. Clean up any open transactions (defensive cleanup)
                 # 3. Clean up session-specific resources
-                
+
                 session_cleanup_count = 0
-                
+
                 # Clean up any orphaned prepared statements
                 if self.prepared_statements:
                     session_cleanup_count += len(self.prepared_statements)
                     self.prepared_statements.clear()
-                    logger.info(f"Cleaned up {session_cleanup_count} prepared statements during session close")
-                
-                # Clean up any orphaned transactions  
+                    logger.info(
+                        f"Cleaned up {session_cleanup_count} prepared statements during session close"
+                    )
+
+                # Clean up any orphaned transactions
                 if self.open_transactions:
                     transaction_cleanup_count = len(self.open_transactions)
                     self.open_transactions.clear()
-                    logger.info(f"Cleaned up {transaction_cleanup_count} transactions during session close")
+                    logger.info(
+                        f"Cleaned up {transaction_cleanup_count} transactions during session close"
+                    )
                     session_cleanup_count += transaction_cleanup_count
-                
+
                 # Clean up any session-specific data
                 if self.open_sessions:
                     session_count = len(self.open_sessions)
                     self.open_sessions.clear()
-                    logger.info(f"Cleaned up {session_count} session entries during session close")
+                    logger.info(
+                        f"Cleaned up {session_count} session entries during session close"
+                    )
                     session_cleanup_count += session_count
-                
-            actions_log.info(f"4. Reply by backend: Session closed, cleaned up {session_cleanup_count} resources")
+
+            actions_log.info(
+                f"4. Reply by backend: Session closed, cleaned up {session_cleanup_count} resources"
+            )
             actions_log.info("5. Reply sent back: CloseSession completed successfully")
-            
+
             logger.info("Session closed successfully")
             print("SERVER: Session closed successfully")
-            
+
             # Return empty result (standard for CloseSession)
             return pf.Result(pa.py_buffer(b""))
-            
+
         except Exception as e:
             logger.error(f"Error closing session: {e}", exc_info=True)
             actions_log.info(f"4. Reply by backend: ERROR - {e}")
@@ -442,8 +452,51 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
             f"{descriptor.descriptor_type}"
         )
 
+        # Support PATH descriptor for raw Flight operations (e.g., verify uploads)
+        if descriptor.descriptor_type == pf.DescriptorType.PATH:
+            try:
+                parts = []
+                if descriptor.path:
+                    for p in descriptor.path:
+                        if isinstance(p, (bytes, bytearray)):
+                            parts.append(p.decode("utf-8"))
+                        else:
+                            parts.append(str(p))
+                table_name = parts[0] if len(parts) == 1 else ".".join(parts)
+                routing_log.info(f"PATH GetFlightInfo for table: {table_name}")
+                schema = self.backend.get_table_schema(table_name)
+                try:
+                    total_rows = self.backend.get_table_row_count(table_name)
+                except Exception as e:
+                    logger.debug(f"Row count unavailable for {table_name}: {e}")
+                    total_rows = 0
+                endpoint = pf.FlightEndpoint(
+                    ticket=pf.Ticket(f"PATH:{table_name}".encode("utf-8")),
+                    locations=[self.advertised_location],
+                )
+                return pf.FlightInfo(
+                    schema=schema,
+                    descriptor=descriptor,
+                    endpoints=[endpoint],
+                    total_records=total_rows,
+                    total_bytes=0,
+                )
+            except Exception as e:
+                logger.error(f"PATH GetFlightInfo failed: {e}", exc_info=True)
+                empty_schema = pa.schema([])
+                endpoint = pf.FlightEndpoint(
+                    ticket=pf.Ticket(b""), locations=[self.advertised_location]
+                )
+                return pf.FlightInfo(
+                    schema=empty_schema,
+                    descriptor=descriptor,
+                    endpoints=[endpoint],
+                    total_records=0,
+                    total_bytes=0,
+                )
+
         if descriptor.descriptor_type != pf.DescriptorType.CMD:
-            raise NotImplementedError("Only CMD descriptors are supported.")
+            raise NotImplementedError("Only CMD and PATH descriptors are supported.")
 
         command_bytes = descriptor.command
         logger.info(f"GetFlightInfo command length: {len(command_bytes)} bytes")
@@ -717,11 +770,15 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
                     actions_handler.flush()
 
                     # Retrieve stored parameters for this prepared statement
-                    stored_params = self.prepared_statements[handle].get("parameters", [])
+                    stored_params = self.prepared_statements[handle].get(
+                        "parameters", []
+                    )
                     if stored_params:
                         # Convert parameter batches to Python list format for DuckDB
                         params = self._convert_parameter_batches_to_list(stored_params)
-                        logger.info(f"Retrieved stored parameters for prepared statement: {params}")
+                        logger.info(
+                            f"Retrieved stored parameters for prepared statement: {params}"
+                        )
                         print(f"SERVER: Retrieved stored parameters: {params}")
                     else:
                         params = None
@@ -778,6 +835,48 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
         print(
             f"SERVER: do_put called with descriptor type: {descriptor.descriptor_type}"
         )
+
+        # Handle raw Flight PATH uploads (Arrow table ingestion)
+        if descriptor.descriptor_type == pf.DescriptorType.PATH:
+            try:
+                parts = []
+                if descriptor.path:
+                    for p in descriptor.path:
+                        if isinstance(p, (bytes, bytearray)):
+                            parts.append(p.decode("utf-8"))
+                        else:
+                            parts.append(str(p))
+                table_name = parts[0] if len(parts) == 1 else ".".join(parts)
+
+                actions_log.info(f"RAW PATH do_put → table: {table_name}")
+                actions_handler.flush()
+
+                incoming_schema = getattr(reader, "schema", None)
+                if incoming_schema is None:
+                    raise ValueError("PATH do_put requires schema from client")
+
+                # Create empty table, then append all incoming batches
+                self.backend.create_table_from_schema(table_name, incoming_schema)
+                while True:
+                    try:
+                        chunk = reader.read_chunk()
+                    except StopIteration:
+                        break
+                    if not chunk or chunk.data is None:
+                        break
+                    batch_table = pa.Table.from_batches([chunk.data])
+                    self.backend.append_table_from_arrow(table_name, batch_table)
+
+                try:
+                    writer.write(pa.py_buffer(b""))
+                except Exception:
+                    pass
+                logger.info(f"Completed PATH do_put for table: {table_name}")
+                print(f"SERVER: PATH do_put completed for table: {table_name}")
+                return
+            except Exception as e:
+                logger.error(f"Error in PATH do_put: {e}", exc_info=True)
+                raise
         command_bytes = descriptor.command
         any_command = parse_any_command(command_bytes)
         if not any_command:
@@ -873,7 +972,7 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
                 if parameter_batches:
                     params = self._extract_parameters_from_batches(parameter_batches)
                     actions_log.info(f"Extracted parameters: {params}")
-                    
+
                 record_count = self._do_put_update_from_query(query, params)
 
                 result = DoPutUpdateResult(record_count=record_count)
@@ -1154,7 +1253,9 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
         query = command.query
         return self._do_get_statement_from_query(query)
 
-    def _do_get_statement_from_query(self, query: str, params: Optional[List] = None) -> pf.FlightDataStream:
+    def _do_get_statement_from_query(
+        self, query: str, params: Optional[List] = None
+    ) -> pf.FlightDataStream:
         logger.info(f"Executing query: {query}")
         print(f"SERVER: Executing query: {query}")
         if params:
@@ -1165,7 +1266,9 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
         actions_log.info("1. Receiving command: SQL Query")
         actions_log.info(f"2. Command arguments: {query}")
         if params:
-            actions_log.info(f"3. Command sent to DuckDB: {query} with parameters {params}")
+            actions_log.info(
+                f"3. Command sent to DuckDB: {query} with parameters {params}"
+            )
         else:
             actions_log.info(f"3. Command sent to DuckDB: {query}")
         actions_handler.flush()
@@ -1191,42 +1294,50 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
             error_table = pa.table({"error": pa.array([str(e)])}, schema=error_schema)
             return pf.RecordBatchStream(error_table)
 
-    def _convert_parameter_batches_to_list(self, parameter_batches: List[pa.RecordBatch]) -> List:
+    def _convert_parameter_batches_to_list(
+        self, parameter_batches: List[pa.RecordBatch]
+    ) -> List:
         """
         Convert PyArrow parameter batches to a simple Python list for DuckDB.
-        
-        The client sends parameters as PyArrow record batches, but DuckDB expects 
+
+        The client sends parameters as PyArrow record batches, but DuckDB expects
         a simple Python list of values like [19] for a single parameter.
         """
         if not parameter_batches:
             return []
-        
+
         try:
             params = []
-            
+
             # Iterate through all parameter batches
             for batch in parameter_batches:
-                logger.info(f"Processing parameter batch with {batch.num_columns} columns and {batch.num_rows} rows")
-                
+                logger.info(
+                    f"Processing parameter batch with {batch.num_columns} columns and {batch.num_rows} rows"
+                )
+
                 # For each row in the batch (each row represents one execution)
                 for row_idx in range(batch.num_rows):
                     row_params = []
-                    
+
                     # For each column in the batch (each column is a parameter)
                     for col_idx in range(batch.num_columns):
                         column = batch.column(col_idx)
-                        value = column[row_idx].as_py()  # Convert Arrow scalar to Python value
+                        value = column[
+                            row_idx
+                        ].as_py()  # Convert Arrow scalar to Python value
                         row_params.append(value)
-                        logger.info(f"Parameter {col_idx}: {value} (type: {type(value)})")
-                    
+                        logger.info(
+                            f"Parameter {col_idx}: {value} (type: {type(value)})"
+                        )
+
                     # For prepared statements, we typically expect one row of parameters
                     # If there are multiple rows, we take the first one
                     if row_idx == 0:
                         params.extend(row_params)
-                    
+
             logger.info(f"Converted parameter batches to: {params}")
             return params
-            
+
         except Exception as e:
             logger.error(f"Error converting parameter batches: {e}", exc_info=True)
             return []
@@ -1328,7 +1439,9 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
         query = command.query
         return self._do_put_update_from_query(query)
 
-    def _do_put_update_from_query(self, query: str, params: Optional[List] = None) -> int:
+    def _do_put_update_from_query(
+        self, query: str, params: Optional[List] = None
+    ) -> int:
         actions_log.info("1. Receiving command: SQL Update")
         actions_log.info(f"2. Command arguments: {query}")
         actions_log.info(f"3. Command sent to DuckDB: {query}")
@@ -1346,7 +1459,9 @@ class MinimalFlightSQLServer(pf.FlightServerBase):
             actions_log.info("5. Reply sent back: Error")
             raise e
 
-    def _extract_parameters_from_batches(self, parameter_batches: List[pa.RecordBatch]) -> List:
+    def _extract_parameters_from_batches(
+        self, parameter_batches: List[pa.RecordBatch]
+    ) -> List:
         """Extract parameter values from PyArrow record batches into a flat list."""
         params = []
         for batch in parameter_batches:

--- a/src/mpzsql/flightsql/protobuf.py
+++ b/src/mpzsql/flightsql/protobuf.py
@@ -10,27 +10,51 @@ import struct
 import uuid
 from typing import Optional, Tuple
 
-from google.protobuf import any_pb2
 import pyarrow as pa
+from google.protobuf import any_pb2
 
-from mpzsql.logfire_config import get_protobuf_logger
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    ActionBeginTransactionRequest as GeneratedActionBeginTransactionRequest,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    ActionBeginTransactionResult as GeneratedActionBeginTransactionResult,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    ActionClosePreparedStatementRequest as GeneratedActionClosePreparedStatementRequest,
+)
 
 # Import generated protobuf classes for gradual replacement
 from mpzsql.flightsql.generated.FlightSql_pb2 import (
     ActionCreatePreparedStatementRequest as GeneratedActionCreatePreparedStatementRequest,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
     ActionCreatePreparedStatementResult as GeneratedActionCreatePreparedStatementResult,
-    ActionClosePreparedStatementRequest as GeneratedActionClosePreparedStatementRequest,
-    ActionBeginTransactionRequest as GeneratedActionBeginTransactionRequest,
-    ActionBeginTransactionResult as GeneratedActionBeginTransactionResult,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
     ActionEndTransactionRequest as GeneratedActionEndTransactionRequest,
-    CommandStatementQuery as GeneratedCommandStatementQuery,
-    CommandStatementUpdate as GeneratedCommandStatementUpdate,
-    CommandPreparedStatementQuery as GeneratedCommandPreparedStatementQuery,
-    CommandPreparedStatementUpdate as GeneratedCommandPreparedStatementUpdate,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
     CommandGetDbSchemas as GeneratedCommandGetDbSchemas,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
     CommandGetTables as GeneratedCommandGetTables,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    CommandPreparedStatementQuery as GeneratedCommandPreparedStatementQuery,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    CommandPreparedStatementUpdate as GeneratedCommandPreparedStatementUpdate,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    CommandStatementQuery as GeneratedCommandStatementQuery,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
+    CommandStatementUpdate as GeneratedCommandStatementUpdate,
+)
+from mpzsql.flightsql.generated.FlightSql_pb2 import (
     DoPutUpdateResult as GeneratedDoPutUpdateResult,
 )
+from mpzsql.logfire_config import get_protobuf_logger
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +67,11 @@ protobuf_log = logging.getLogger("server_protobuf")
 protobuf_log.setLevel(logging.DEBUG)
 
 # Create a file handler for the protobuf logger
-protobuf_fh = logging.FileHandler("server_protobuf.log", mode='w')
+protobuf_fh = logging.FileHandler("server_protobuf.log", mode="w")
 protobuf_fh.setLevel(logging.DEBUG)
 
 # Create a formatter and set it for the handler
-protobuf_formatter = logging.Formatter('%(asctime)s - %(message)s')
+protobuf_formatter = logging.Formatter("%(asctime)s - %(message)s")
 protobuf_fh.setFormatter(protobuf_formatter)
 
 # Add the handler to the logger
@@ -62,14 +86,28 @@ protobuf_log.info("Legacy protobuf logger initialized")
 def parse_any_command(command_bytes: bytes) -> Optional[any_pb2.Any]:
     """Parse command bytes into a protobuf Any message."""
     try:
-        protobuf_log.info(f"parse_any_command called with {len(command_bytes)} bytes: {command_bytes.hex()}")
-        protobuf_logger.info("Parsing protobuf Any command", 
-                           bytes_length=len(command_bytes), 
-                           bytes_hex=command_bytes.hex())
+        # Guard against None/empty input (e.g., PATH descriptors)
+        if not command_bytes:
+            protobuf_log.info(
+                "parse_any_command called with empty bytes; returning None"
+            )
+            return None
+        protobuf_log.info(
+            f"parse_any_command called with {len(command_bytes)} bytes: {command_bytes.hex()}"
+        )
+        protobuf_logger.info(
+            "Parsing protobuf Any command",
+            bytes_length=len(command_bytes),
+            bytes_hex=command_bytes.hex(),
+        )
         any_message = any_pb2.Any()
         any_message.ParseFromString(command_bytes)
-        protobuf_log.info(f"Successfully parsed Any message with type_url: {any_message.type_url}")
-        protobuf_logger.info("Successfully parsed Any message", type_url=any_message.type_url)
+        protobuf_log.info(
+            f"Successfully parsed Any message with type_url: {any_message.type_url}"
+        )
+        protobuf_logger.info(
+            "Successfully parsed Any message", type_url=any_message.type_url
+        )
         return any_message
     except Exception as e:
         protobuf_log.error(f"Could not parse command as protobuf Any: {e}")
@@ -90,8 +128,8 @@ class ActionCreatePreparedStatementRequest:
     @property
     def query(self):
         return self._generated.query
-    
-    @query.setter 
+
+    @query.setter
     def query(self, value):
         self._generated.query = value
 
@@ -100,21 +138,27 @@ class ActionCreatePreparedStatementRequest:
         Parse using generated protobuf class - much simpler and more reliable!
         """
         try:
-            logger.info(f"ActionCreatePreparedStatementRequest: parsing {len(data)} bytes: {data.hex()}")
-            
+            logger.info(
+                f"ActionCreatePreparedStatementRequest: parsing {len(data)} bytes: {data.hex()}"
+            )
+
             # Try parsing as Any message first (wrapper format)
             any_msg = any_pb2.Any()
             any_msg.ParseFromString(data)
-            
-            # Extract the inner message 
+
+            # Extract the inner message
             self._generated.ParseFromString(any_msg.value)
-            logger.info(f"Successfully parsed ActionCreatePreparedStatementRequest query: '{self.query}'")
-            
+            logger.info(
+                f"Successfully parsed ActionCreatePreparedStatementRequest query: '{self.query}'"
+            )
+
         except Exception:
             # Fallback: try parsing directly (no Any wrapper)
             try:
                 self._generated.ParseFromString(data)
-                logger.info(f"Successfully parsed ActionCreatePreparedStatementRequest (direct) query: '{self.query}'")
+                logger.info(
+                    f"Successfully parsed ActionCreatePreparedStatementRequest (direct) query: '{self.query}'"
+                )
             except Exception as e:
                 logger.error(f"Error parsing ActionCreatePreparedStatementRequest: {e}")
                 self._generated.query = ""
@@ -123,7 +167,7 @@ class ActionCreatePreparedStatementRequest:
 class ActionClosePreparedStatementRequest:
     """
     Request to close a prepared statement.
-    
+
     Now using generated protobuf class for proper and reliable parsing!
     """
 
@@ -146,18 +190,23 @@ class ActionClosePreparedStatementRequest:
         """
         try:
             self._generated.ParseFromString(data)
-            logger.info(f"Successfully parsed ActionClosePreparedStatementRequest using generated class: {self.prepared_statement_handle.hex()}")
+            logger.info(
+                f"Successfully parsed ActionClosePreparedStatementRequest using generated class: {self.prepared_statement_handle.hex()}"
+            )
         except Exception as e:
-            logger.error(f"Error parsing ActionClosePreparedStatementRequest using generated class: {e}")
+            logger.error(
+                f"Error parsing ActionClosePreparedStatementRequest using generated class: {e}"
+            )
             self._generated.prepared_statement_handle = b""
 
 
 class ActionBeginTransactionRequest:
     """
     Request to begin a transaction.
-    
+
     Now using generated protobuf class for proper and reliable parsing!
     """
+
     def __init__(self):
         self._generated = GeneratedActionBeginTransactionRequest()
 
@@ -165,16 +214,22 @@ class ActionBeginTransactionRequest:
         """Parse using generated protobuf class - much simpler and more reliable!"""
         try:
             self._generated.ParseFromString(data)
-            logger.debug("Successfully parsed ActionBeginTransactionRequest using generated class")
+            logger.debug(
+                "Successfully parsed ActionBeginTransactionRequest using generated class"
+            )
         except Exception as e:
-            logger.error(f"Error parsing ActionBeginTransactionRequest using generated class: {e}")
+            logger.error(
+                f"Error parsing ActionBeginTransactionRequest using generated class: {e}"
+            )
+
 
 class ActionEndTransactionRequest:
     """
     Request to end a transaction.
-    
+
     Now using generated protobuf class for proper and reliable parsing!
     """
+
     def __init__(self, transaction_id: bytes = b"", action: int = 0):
         self._generated = GeneratedActionEndTransactionRequest()
         if transaction_id:
@@ -205,14 +260,18 @@ class ActionEndTransactionRequest:
         """Parse using generated protobuf class - much simpler and more reliable!"""
         try:
             self._generated.ParseFromString(data)
-            logger.debug(f"Successfully parsed ActionEndTransactionRequest using generated class: transaction_id={self.transaction_id.hex()}, action={self.action}")
+            logger.debug(
+                f"Successfully parsed ActionEndTransactionRequest using generated class: transaction_id={self.transaction_id.hex()}, action={self.action}"
+            )
         except Exception as e:
-            logger.error(f"Error parsing ActionEndTransactionRequest using generated class: {e}")
+            logger.error(
+                f"Error parsing ActionEndTransactionRequest using generated class: {e}"
+            )
 
 
 class DoPutUpdateResult:
     """Represents a DoPutUpdateResult.
-    
+
     Now using generated protobuf class with manual compatibility wrapper.
     """
 
@@ -220,10 +279,10 @@ class DoPutUpdateResult:
         self._generated = GeneratedDoPutUpdateResult()
         self._generated.record_count = record_count
 
-    @property 
+    @property
     def record_count(self):
         return self._generated.record_count
-    
+
     @record_count.setter
     def record_count(self, value):
         self._generated.record_count = value
@@ -235,11 +294,14 @@ class DoPutUpdateResult:
 
 class CommandGetCatalogs:
     """Represents a CommandGetCatalogs."""
+
     def __init__(self):
         pass
 
+
 class CommandGetDbSchemas:
     """Represents a CommandGetDbSchemas."""
+
     def __init__(self):
         self.catalog = None
         self.db_schema_filter_pattern = None
@@ -250,6 +312,7 @@ class CommandGetDbSchemas:
 
 class CommandGetTables:
     """Represents a CommandGetTables."""
+
     def __init__(self):
         self.catalog = None
         self.db_schema_filter_pattern = None
@@ -260,13 +323,17 @@ class CommandGetTables:
     def ParseFromString(self, data: bytes):
         pass
 
+
 class CommandGetTableTypes:
     """Represents a CommandGetTableTypes."""
+
     def __init__(self):
         pass
 
+
 class CommandGetColumns:
     """Represents a CommandGetColumns."""
+
     def __init__(self):
         self.catalog = None
         self.db_schema_filter_pattern = None
@@ -276,27 +343,31 @@ class CommandGetColumns:
     def ParseFromString(self, data: bytes):
         pass
 
+
 class CommandGetSqlInfo:
     """Represents a CommandGetSqlInfo."""
+
     def __init__(self):
         self.info = []
 
     def ParseFromString(self, data: bytes):
         pass
 
+
 class CommandStatementQuery:
     """Represents a CommandStatementQuery.
-    
+
     Now using generated protobuf class for simpler and more reliable parsing.
     """
+
     def __init__(self):
         self._generated = GeneratedCommandStatementQuery()
 
     @property
     def query(self):
         return self._generated.query
-    
-    @query.setter 
+
+    @query.setter
     def query(self, value):
         self._generated.query = value
 
@@ -308,19 +379,21 @@ class CommandStatementQuery:
             logger.error(f"Error parsing CommandStatementQuery: {e}")
             self._generated.query = ""
 
+
 class CommandStatementUpdate:
     """Represents a CommandStatementUpdate.
-    
+
     Now using generated protobuf class for simpler and more reliable parsing.
     """
+
     def __init__(self):
         self._generated = GeneratedCommandStatementUpdate()
 
     @property
     def query(self):
         return self._generated.query
-    
-    @query.setter 
+
+    @query.setter
     def query(self, value):
         self._generated.query = value
 
@@ -336,7 +409,9 @@ class CommandStatementUpdate:
         """Parse from Any protobuf message using generated class."""
         try:
             self._generated.ParseFromString(any_command.value)
-            logger.info(f"Successfully parsed CommandStatementUpdate query: {self.query}")
+            logger.info(
+                f"Successfully parsed CommandStatementUpdate query: {self.query}"
+            )
         except Exception as e:
             logger.error(f"Error unpacking CommandStatementUpdate: {e}")
             self._generated.query = ""
@@ -344,17 +419,18 @@ class CommandStatementUpdate:
 
 class CommandPreparedStatementQuery:
     """Represents a CommandPreparedStatementQuery.
-    
+
     Now using generated protobuf class for simpler and more reliable parsing.
     """
+
     def __init__(self):
         self._generated = GeneratedCommandPreparedStatementQuery()
 
     @property
     def prepared_statement_handle(self):
         return self._generated.prepared_statement_handle
-    
-    @prepared_statement_handle.setter 
+
+    @prepared_statement_handle.setter
     def prepared_statement_handle(self, value):
         self._generated.prepared_statement_handle = value
 
@@ -377,17 +453,18 @@ class CommandPreparedStatementQuery:
 
 class CommandPreparedStatementUpdate:
     """Represents a CommandPreparedStatementUpdate.
-    
+
     Now using generated protobuf class for simpler and more reliable parsing.
     """
+
     def __init__(self):
         self._generated = GeneratedCommandPreparedStatementUpdate()
 
     @property
     def prepared_statement_handle(self):
         return self._generated.prepared_statement_handle
-    
-    @prepared_statement_handle.setter 
+
+    @prepared_statement_handle.setter
     def prepared_statement_handle(self, value):
         self._generated.prepared_statement_handle = value
 
@@ -410,14 +487,15 @@ class CommandPreparedStatementUpdate:
 
 class PreparedStatementQuery:
     """Represents a PreparedStatementQuery."""
+
     def __init__(self):
         self.prepared_statement_handle = b""
 
     def ParseFromString(self, data: bytes):
-        if data and data[0] == 0x0a:
+        if data and data[0] == 0x0A:
             length = data[1]
             if len(data) >= 2 + length:
-                self.prepared_statement_handle = data[2:2+length]
+                self.prepared_statement_handle = data[2 : 2 + length]
 
     def Unpack(self, any_message):
         """Parse the handle from the PreparedStatementQuery protobuf message."""
@@ -489,14 +567,14 @@ class FlightSQLProtobuf:
     ) -> bytes:
         """
         Create ActionCreatePreparedStatementResult protobuf message.
-        
+
         Now using generated protobuf class for proper and reliable serialization!
         """
         try:
             # Use generated protobuf class - much simpler and more reliable!
             result = GeneratedActionCreatePreparedStatementResult()
             result.prepared_statement_handle = prepared_statement_handle
-            
+
             if dataset_schema:
                 result.dataset_schema = dataset_schema
             if parameter_schema:
@@ -524,13 +602,13 @@ class FlightSQLProtobuf:
     def parse_command_prepared_statement_query(command_bytes: bytes) -> Optional[str]:
         """
         Parse CommandPreparedStatementQuery protobuf message to extract prepared statement handle.
-        
+
         Now using our improved CommandPreparedStatementQuery class!
         """
         try:
             # Use our already-improved class with generated protobuf
             command = CommandPreparedStatementQuery()
-            
+
             # Try parsing as protobuf Any message first
             try:
                 any_message = any_pb2.Any()
@@ -544,7 +622,7 @@ class FlightSQLProtobuf:
                     if command.prepared_statement_handle:
                         # Convert bytes to string if needed
                         if isinstance(command.prepared_statement_handle, bytes):
-                            handle = command.prepared_statement_handle.decode('utf-8')
+                            handle = command.prepared_statement_handle.decode("utf-8")
                         else:
                             handle = str(command.prepared_statement_handle)
                         logger.debug(f"Extracted prepared statement handle: {handle}")
@@ -557,7 +635,7 @@ class FlightSQLProtobuf:
             command.ParseFromString(command_bytes)
             if command.prepared_statement_handle:
                 if isinstance(command.prepared_statement_handle, bytes):
-                    handle = command.prepared_statement_handle.decode('utf-8')
+                    handle = command.prepared_statement_handle.decode("utf-8")
                 else:
                     handle = str(command.prepared_statement_handle)
                 return handle
@@ -609,13 +687,17 @@ class FlightSQLProtobuf:
         Now using generated protobuf class for proper and reliable parsing!
         """
         try:
-            protobuf_log.info(f"parse_command_statement_query called with {len(command_bytes)} bytes: {command_bytes.hex()}")
-            
+            protobuf_log.info(
+                f"parse_command_statement_query called with {len(command_bytes)} bytes: {command_bytes.hex()}"
+            )
+
             # Try parsing as protobuf Any message first
             try:
                 any_message = any_pb2.Any()
                 any_message.ParseFromString(command_bytes)
-                protobuf_log.info(f"Parsed as Any message with type_url: {any_message.type_url}")
+                protobuf_log.info(
+                    f"Parsed as Any message with type_url: {any_message.type_url}"
+                )
 
                 if (
                     any_message.type_url
@@ -624,10 +706,12 @@ class FlightSQLProtobuf:
                     # Use generated protobuf class - much simpler and more reliable!
                     command = GeneratedCommandStatementQuery()
                     command.ParseFromString(any_message.value)
-                    
+
                     if command.query:
                         sql = command.query
-                        protobuf_log.info(f"Successfully extracted SQL using generated class: {sql}")
+                        protobuf_log.info(
+                            f"Successfully extracted SQL using generated class: {sql}"
+                        )
                         return sql
 
             except Exception as e:
@@ -638,10 +722,12 @@ class FlightSQLProtobuf:
             try:
                 command = GeneratedCommandStatementQuery()
                 command.ParseFromString(command_bytes)
-                
+
                 if command.query:
                     sql = command.query
-                    protobuf_log.info(f"Successfully extracted SQL using generated class (direct): {sql}")
+                    protobuf_log.info(
+                        f"Successfully extracted SQL using generated class (direct): {sql}"
+                    )
                     return sql
             except Exception as e:
                 protobuf_log.debug(f"Direct parsing with generated class failed: {e}")
@@ -659,12 +745,16 @@ class FlightSQLProtobuf:
                         and not sql_stripped.startswith("\x01")
                         and (" " in sql_stripped or len(sql_stripped) > 3)
                     ):
-                        protobuf_log.info(f"Successfully decoded SQL (fallback decode): {sql_stripped}")
+                        protobuf_log.info(
+                            f"Successfully decoded SQL (fallback decode): {sql_stripped}"
+                        )
                         return sql_stripped
             except UnicodeDecodeError:
                 pass
 
-            protobuf_log.warning(f"Could not extract SQL from {len(command_bytes)} bytes")
+            protobuf_log.warning(
+                f"Could not extract SQL from {len(command_bytes)} bytes"
+            )
             logger.warning(f"Could not extract SQL from {len(command_bytes)} bytes")
             return None
 
@@ -674,87 +764,148 @@ class FlightSQLProtobuf:
             return None
 
     @staticmethod
-    def parse_command_get_db_schemas(command_bytes: bytes) -> Tuple[Optional[str], Optional[str]]:
+    def parse_command_get_db_schemas(
+        command_bytes: bytes,
+    ) -> Tuple[Optional[str], Optional[str]]:
         """
         Parse CommandGetDbSchemas protobuf message to extract catalog and schema filter.
-        
+
         Now using generated protobuf class for proper and reliable parsing!
-        
+
         Returns:
             Tuple of (catalog, db_schema_filter_pattern)
         """
         try:
-            protobuf_log.info(f"parse_command_get_db_schemas called with {len(command_bytes)} bytes: {command_bytes.hex()}")
-            
+            protobuf_log.info(
+                f"parse_command_get_db_schemas called with {len(command_bytes)} bytes: {command_bytes.hex()}"
+            )
+
             # Use generated protobuf class - much simpler and more reliable!
             command = GeneratedCommandGetDbSchemas()
             command.ParseFromString(command_bytes)
-            
+
             catalog = command.catalog if command.catalog else None
-            db_schema_filter_pattern = command.db_schema_filter_pattern if command.db_schema_filter_pattern else None
-            
-            protobuf_log.info(f"Parsed GetDbSchemas using generated class: catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}")
+            db_schema_filter_pattern = (
+                command.db_schema_filter_pattern
+                if command.db_schema_filter_pattern
+                else None
+            )
+
+            protobuf_log.info(
+                f"Parsed GetDbSchemas using generated class: catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}"
+            )
             return catalog, db_schema_filter_pattern
-            
+
         except Exception as e:
             protobuf_log.error(f"Error parsing CommandGetDbSchemas: {e}")
             return None, None
 
     @staticmethod
-    def parse_command_get_tables(command_bytes: bytes) -> Tuple[Optional[str], Optional[str], Optional[str], list, bool]:
+    def parse_command_get_tables(
+        command_bytes: bytes,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str], list, bool]:
         """
         Parse CommandGetTables protobuf message to extract parameters.
-        
+
         Now using generated protobuf class for proper and reliable parsing!
-        
+
         Returns:
             Tuple of (catalog, db_schema_filter_pattern, table_name_filter_pattern, table_types, include_schema)
         """
         try:
-            protobuf_log.info(f"parse_command_get_tables called with {len(command_bytes)} bytes: {command_bytes.hex()}")
-            
+            protobuf_log.info(
+                f"parse_command_get_tables called with {len(command_bytes)} bytes: {command_bytes.hex()}"
+            )
+
             # Try parsing as protobuf Any message first
             try:
                 any_message = any_pb2.Any()
                 any_message.ParseFromString(command_bytes)
-                
-                if any_message.type_url == FlightSQLProtobuf.COMMAND_GET_TABLES_TYPE_URL:
+
+                if (
+                    any_message.type_url
+                    == FlightSQLProtobuf.COMMAND_GET_TABLES_TYPE_URL
+                ):
                     # Use generated protobuf class - much simpler and more reliable!
                     command = GeneratedCommandGetTables()
                     command.ParseFromString(any_message.value)
-                    
+
                     catalog = command.catalog if command.catalog else None
-                    db_schema_filter_pattern = command.db_schema_filter_pattern if command.db_schema_filter_pattern else None
-                    table_name_filter_pattern = command.table_name_filter_pattern if command.table_name_filter_pattern else None
-                    table_types = list(command.table_types) if command.table_types else []
-                    include_schema = command.include_schema if hasattr(command, 'include_schema') else False
-                    
-                    protobuf_log.info(f"Parsed GetTables using generated class: catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}, table_name_filter_pattern={table_name_filter_pattern}, table_types={table_types}, include_schema={include_schema}")
-                    return catalog, db_schema_filter_pattern, table_name_filter_pattern, table_types, include_schema
-                    
+                    db_schema_filter_pattern = (
+                        command.db_schema_filter_pattern
+                        if command.db_schema_filter_pattern
+                        else None
+                    )
+                    table_name_filter_pattern = (
+                        command.table_name_filter_pattern
+                        if command.table_name_filter_pattern
+                        else None
+                    )
+                    table_types = (
+                        list(command.table_types) if command.table_types else []
+                    )
+                    include_schema = (
+                        command.include_schema
+                        if hasattr(command, "include_schema")
+                        else False
+                    )
+
+                    protobuf_log.info(
+                        f"Parsed GetTables using generated class: catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}, table_name_filter_pattern={table_name_filter_pattern}, table_types={table_types}, include_schema={include_schema}"
+                    )
+                    return (
+                        catalog,
+                        db_schema_filter_pattern,
+                        table_name_filter_pattern,
+                        table_types,
+                        include_schema,
+                    )
+
             except Exception as e:
                 protobuf_log.debug(f"Not a protobuf Any message: {e}")
-                
+
             # Try parsing directly as command bytes (without Any wrapper)
             try:
                 command = GeneratedCommandGetTables()
                 command.ParseFromString(command_bytes)
-                
+
                 catalog = command.catalog if command.catalog else None
-                db_schema_filter_pattern = command.db_schema_filter_pattern if command.db_schema_filter_pattern else None
-                table_name_filter_pattern = command.table_name_filter_pattern if command.table_name_filter_pattern else None
+                db_schema_filter_pattern = (
+                    command.db_schema_filter_pattern
+                    if command.db_schema_filter_pattern
+                    else None
+                )
+                table_name_filter_pattern = (
+                    command.table_name_filter_pattern
+                    if command.table_name_filter_pattern
+                    else None
+                )
                 table_types = list(command.table_types) if command.table_types else []
-                include_schema = command.include_schema if hasattr(command, 'include_schema') else False
-                
-                protobuf_log.info(f"Parsed GetTables using generated class (direct): catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}, table_name_filter_pattern={table_name_filter_pattern}, table_types={table_types}, include_schema={include_schema}")
-                return catalog, db_schema_filter_pattern, table_name_filter_pattern, table_types, include_schema
-                
+                include_schema = (
+                    command.include_schema
+                    if hasattr(command, "include_schema")
+                    else False
+                )
+
+                protobuf_log.info(
+                    f"Parsed GetTables using generated class (direct): catalog={catalog}, db_schema_filter_pattern={db_schema_filter_pattern}, table_name_filter_pattern={table_name_filter_pattern}, table_types={table_types}, include_schema={include_schema}"
+                )
+                return (
+                    catalog,
+                    db_schema_filter_pattern,
+                    table_name_filter_pattern,
+                    table_types,
+                    include_schema,
+                )
+
             except Exception as e:
                 protobuf_log.debug(f"Direct parsing with generated class failed: {e}")
-            
-            protobuf_log.warning(f"Could not parse GetTables from {len(command_bytes)} bytes")
+
+            protobuf_log.warning(
+                f"Could not parse GetTables from {len(command_bytes)} bytes"
+            )
             return None, None, None, [], False
-            
+
         except Exception as e:
             protobuf_log.error(f"Error parsing CommandGetTables: {e}")
             return None, None, None, [], False
@@ -776,7 +927,7 @@ class FlightSQLProtobuf:
     def parse_create_prepared_statement_request(action_body: bytes) -> Optional[str]:
         """
         Parse CreatePreparedStatement request to extract SQL.
-        
+
         Now using generated protobuf class for proper and reliable parsing!
         """
         try:
@@ -787,11 +938,13 @@ class FlightSQLProtobuf:
             # Use our already-improved ActionCreatePreparedStatementRequest class
             request = ActionCreatePreparedStatementRequest()
             request.ParseFromString(action_body)
-            
+
             if request.query:
-                logger.info(f"Extracted query from ActionCreatePreparedStatementRequest using generated class: {request.query}")
+                logger.info(
+                    f"Extracted query from ActionCreatePreparedStatementRequest using generated class: {request.query}"
+                )
                 return request.query
-            
+
             logger.warning("Query not found in ActionCreatePreparedStatementRequest")
             return None
 
@@ -803,19 +956,23 @@ class FlightSQLProtobuf:
     def parse_close_prepared_statement_request(action_body: bytes) -> Optional[bytes]:
         """
         Parse ClosePreparedStatement request to extract prepared statement handle.
-        
+
         Now using our improved ActionClosePreparedStatementRequest class!
         """
         try:
             # Use our already-defined class with manual parsing
             request = ActionClosePreparedStatementRequest()
             request.ParseFromString(action_body)
-            
+
             if request.prepared_statement_handle:
-                logger.info(f"Extracted prepared statement handle from ActionClosePreparedStatementRequest: {request.prepared_statement_handle.hex()}")
+                logger.info(
+                    f"Extracted prepared statement handle from ActionClosePreparedStatementRequest: {request.prepared_statement_handle.hex()}"
+                )
                 return request.prepared_statement_handle
-            
-            logger.warning("Prepared statement handle not found in ActionClosePreparedStatementRequest")
+
+            logger.warning(
+                "Prepared statement handle not found in ActionClosePreparedStatementRequest"
+            )
             return None
 
         except Exception as e:
@@ -842,10 +999,12 @@ class FlightSQLProtobuf:
                     # Use generated protobuf class - much simpler and more reliable!
                     command = GeneratedCommandPreparedStatementUpdate()
                     command.ParseFromString(any_message.value)
-                    
+
                     if command.prepared_statement_handle:
                         handle = command.prepared_statement_handle
-                        logger.debug(f"Extracted prepared statement handle using generated class: {handle.hex()}")
+                        logger.debug(
+                            f"Extracted prepared statement handle using generated class: {handle.hex()}"
+                        )
                         return handle
 
             except Exception as e:
@@ -855,10 +1014,12 @@ class FlightSQLProtobuf:
             try:
                 command = GeneratedCommandPreparedStatementUpdate()
                 command.ParseFromString(command_bytes)
-                
+
                 if command.prepared_statement_handle:
                     handle = command.prepared_statement_handle
-                    logger.debug(f"Extracted prepared statement handle using generated class (direct): {handle.hex()}")
+                    logger.debug(
+                        f"Extracted prepared statement handle using generated class (direct): {handle.hex()}"
+                    )
                     return handle
             except Exception as e:
                 logger.debug(f"Direct parsing with generated class failed: {e}")
@@ -872,7 +1033,7 @@ class FlightSQLProtobuf:
                     if handle.startswith("stmt_") or (
                         handle.isalnum() and len(handle) > 5
                     ):
-                        return handle.strip().encode('utf-8')
+                        return handle.strip().encode("utf-8")
             except UnicodeDecodeError:
                 pass
 
@@ -892,7 +1053,7 @@ class FlightSQLProtobuf:
                             else:
                                 break
                         if len(handle) > 5:  # More than just "stmt_"
-                            return handle.encode('utf-8')
+                            return handle.encode("utf-8")
             except Exception:
                 pass
 
@@ -922,10 +1083,12 @@ class FlightSQLProtobuf:
                     # Use generated protobuf class - much simpler and more reliable!
                     command = GeneratedCommandStatementUpdate()
                     command.ParseFromString(any_message.value)
-                    
+
                     if command.query:
                         sql = command.query
-                        logger.debug(f"Successfully extracted SQL using generated class: {sql}")
+                        logger.debug(
+                            f"Successfully extracted SQL using generated class: {sql}"
+                        )
                         return sql
 
             except Exception as e:
@@ -935,10 +1098,12 @@ class FlightSQLProtobuf:
             try:
                 command = GeneratedCommandStatementUpdate()
                 command.ParseFromString(command_bytes)
-                
+
                 if command.query:
                     sql = command.query
-                    logger.debug(f"Successfully extracted SQL using generated class (direct): {sql}")
+                    logger.debug(
+                        f"Successfully extracted SQL using generated class (direct): {sql}"
+                    )
                     return sql
             except Exception as e:
                 logger.debug(f"Direct parsing with generated class failed: {e}")
@@ -970,32 +1135,36 @@ class FlightSQLProtobuf:
     @staticmethod
     def get_tables_schema():
         """Get the standard Flight SQL schema for GetTables command.
-        
+
         This is the 5-column schema including REMARKS as per JDBC spec.
         Only used when include_schema=False in the command.
         Uses standard Arrow Flight SQL column names.
         """
-        return pa.schema([
-            ("catalog_name", pa.string()),
-            ("db_schema_name", pa.string()),
-            ("table_name", pa.string()),
-            ("table_type", pa.string()),
-            ("table_remarks", pa.string()),
-        ])
+        return pa.schema(
+            [
+                ("catalog_name", pa.string()),
+                ("db_schema_name", pa.string()),
+                ("table_name", pa.string()),
+                ("table_type", pa.string()),
+                ("table_remarks", pa.string()),
+            ]
+        )
 
     @staticmethod
     def get_tables_schema_minimal():
         """Get the minimal Flight SQL schema for GetTables command without table_schema.
-        
+
         This is the minimal schema according to the Flight SQL specification,
         but most JDBC drivers expect the table_schema column.
         """
-        return pa.schema([
-            ("catalog_name", pa.string()),
-            ("db_schema_name", pa.string()),
-            ("table_name", pa.string()),
-            ("table_type", pa.string()),
-        ])
+        return pa.schema(
+            [
+                ("catalog_name", pa.string()),
+                ("db_schema_name", pa.string()),
+                ("table_name", pa.string()),
+                ("table_type", pa.string()),
+            ]
+        )
 
     @staticmethod
     def get_catalogs_schema():
@@ -1024,39 +1193,49 @@ class FlightSQLProtobuf:
         """Get the extended Flight SQL schema for GetTables command with table schema included.
         Uses standard Arrow Flight SQL column names.
         """
-        return pa.schema([
-            ("catalog_name", pa.string()),
-            ("db_schema_name", pa.string()),
-            ("table_name", pa.string()),
-            ("table_type", pa.string()),
-            ("table_remarks", pa.string()),  # Standard Flight SQL column for comments/remarks
-            ("table_schema", pa.binary()),  # This contains the Arrow schema as bytes
-        ])
+        return pa.schema(
+            [
+                ("catalog_name", pa.string()),
+                ("db_schema_name", pa.string()),
+                ("table_name", pa.string()),
+                ("table_type", pa.string()),
+                (
+                    "table_remarks",
+                    pa.string(),
+                ),  # Standard Flight SQL column for comments/remarks
+                (
+                    "table_schema",
+                    pa.binary(),
+                ),  # This contains the Arrow schema as bytes
+            ]
+        )
 
     @staticmethod
     def get_sql_info_schema():
         """Get the standard Flight SQL schema for GetSqlInfo command.
-        
+
         The schema for SQL info responses should contain:
         - info_name: uint32 NOT NULL (the SQL info code)
         - value: string (simplified - we'll use string values for all info)
-        
+
         Based on the Arrow Flight SQL specification, the proper schema would use
         a dense_union for the value field, but we're simplifying to strings for now.
         """
-        return pa.schema([
-            ("info_name", pa.uint32()),
-            ("value", pa.string()),
-        ])
+        return pa.schema(
+            [
+                ("info_name", pa.uint32()),
+                ("value", pa.string()),
+            ]
+        )
 
     @staticmethod
     def get_sql_info_schema_with_dense_union():
         """Get the proper Flight SQL schema for GetSqlInfo command with dense_union.
-        
+
         This is the proper implementation according to the Arrow Flight SQL specification,
         but it's more complex to implement. The value field should be a dense_union
         that can contain different types (string, int64, bool, etc.).
-        
+
         For now, we're using the simplified string-based schema above.
         """
         # This would be the proper implementation with dense_union
@@ -1067,48 +1246,57 @@ class FlightSQLProtobuf:
             pa.field("int64_value", pa.int64()),
             pa.field("int32_value", pa.int32()),
             pa.field("string_list_value", pa.list_(pa.string())),
-            pa.field("int32_to_int32_list_map_value", pa.map_(pa.int32(), pa.list_(pa.int32()))),
+            pa.field(
+                "int32_to_int32_list_map_value",
+                pa.map_(pa.int32(), pa.list_(pa.int32())),
+            ),
         ]
-        
+
         # Create dense union type
         union_type = pa.union(union_fields, mode="dense")
-        
-        return pa.schema([
-            ("info_name", pa.uint32()),
-            ("value", union_type),
-        ])
+
+        return pa.schema(
+            [
+                ("info_name", pa.uint32()),
+                ("value", union_type),
+            ]
+        )
 
     @staticmethod
     def get_primary_keys_schema():
         """Get the standard Flight SQL schema for GetPrimaryKeys command."""
         # Match Examples server: lowercase field names
-        return pa.schema([
-            ("catalog_name", pa.string()),
-            ("schema_name", pa.string()),
-            ("table_name", pa.string()),
-            ("column_name", pa.string()),
-            ("key_sequence", pa.int32()),
-            ("key_name", pa.string()),
-        ])
+        return pa.schema(
+            [
+                ("catalog_name", pa.string()),
+                ("schema_name", pa.string()),
+                ("table_name", pa.string()),
+                ("column_name", pa.string()),
+                ("key_sequence", pa.int32()),
+                ("key_name", pa.string()),
+            ]
+        )
 
     @staticmethod
     def get_imported_keys_schema():
         """Get the standard Flight SQL schema for GetImportedKeys command."""
-        return pa.schema([
-            ("pk_catalog_name", pa.string()),
-            ("pk_schema_name", pa.string()),
-            ("pk_table_name", pa.string()),
-            ("pk_column_name", pa.string()),
-            ("fk_catalog_name", pa.string()),
-            ("fk_schema_name", pa.string()),
-            ("fk_table_name", pa.string()),
-            ("fk_column_name", pa.string()),
-            ("key_sequence", pa.int32()),
-            ("fk_key_name", pa.string()),
-            ("pk_key_name", pa.string()),
-            ("update_rule", pa.int8()),
-            ("delete_rule", pa.int8()),
-        ])
+        return pa.schema(
+            [
+                ("pk_catalog_name", pa.string()),
+                ("pk_schema_name", pa.string()),
+                ("pk_table_name", pa.string()),
+                ("pk_column_name", pa.string()),
+                ("fk_catalog_name", pa.string()),
+                ("fk_schema_name", pa.string()),
+                ("fk_table_name", pa.string()),
+                ("fk_column_name", pa.string()),
+                ("key_sequence", pa.int32()),
+                ("fk_key_name", pa.string()),
+                ("pk_key_name", pa.string()),
+                ("update_rule", pa.int8()),
+                ("delete_rule", pa.int8()),
+            ]
+        )
 
     @staticmethod
     def get_exported_keys_schema():
@@ -1125,134 +1313,145 @@ class FlightSQLProtobuf:
     @staticmethod
     def get_columns_schema():
         """Get the standard Flight SQL schema for GetColumns command."""
-        return pa.schema([
-            ("catalog_name", pa.string()),
-            ("db_schema_name", pa.string()),
-            ("table_name", pa.string()),
-            ("column_name", pa.string()),
-            ("data_type", pa.int32()),
-            ("type_name", pa.string()),
-            ("column_size", pa.int32()),
-            ("buffer_length", pa.int32()),
-            ("decimal_digits", pa.int32()),
-            ("num_prec_radix", pa.int32()),
-            ("nullable", pa.int32()),
-            ("remarks", pa.string()),
-            ("column_def", pa.string()),
-            ("sql_data_type", pa.int32()),
-            ("sql_datetime_sub", pa.int32()),
-            ("char_octet_length", pa.int32()),
-            ("ordinal_position", pa.int32()),
-            ("is_nullable", pa.string()),
-            ("is_autoincrement", pa.string()),
-            ("is_generatedcolumn", pa.string()),
-        ])
+        return pa.schema(
+            [
+                ("catalog_name", pa.string()),
+                ("db_schema_name", pa.string()),
+                ("table_name", pa.string()),
+                ("column_name", pa.string()),
+                ("data_type", pa.int32()),
+                ("type_name", pa.string()),
+                ("column_size", pa.int32()),
+                ("buffer_length", pa.int32()),
+                ("decimal_digits", pa.int32()),
+                ("num_prec_radix", pa.int32()),
+                ("nullable", pa.int32()),
+                ("remarks", pa.string()),
+                ("column_def", pa.string()),
+                ("sql_data_type", pa.int32()),
+                ("sql_datetime_sub", pa.int32()),
+                ("char_octet_length", pa.int32()),
+                ("ordinal_position", pa.int32()),
+                ("is_nullable", pa.string()),
+                ("is_autoincrement", pa.string()),
+                ("is_generatedcolumn", pa.string()),
+            ]
+        )
 
     @staticmethod
     def create_action_begin_transaction_result(transaction_id: str) -> bytes:
         """
         Create ActionBeginTransactionResult protobuf message.
-        
+
         Now using generated protobuf class for proper and reliable serialization!
         """
         try:
             # Use generated protobuf class - much simpler and more reliable!
             result = GeneratedActionBeginTransactionResult()
-            result.transaction_id = transaction_id.encode('utf-8')
+            result.transaction_id = transaction_id.encode("utf-8")
 
             # Wrap in Any message
             any_message = any_pb2.Any()
-            any_message.type_url = FlightSQLProtobuf.ACTION_BEGIN_TRANSACTION_RESULT_TYPE_URL
+            any_message.type_url = (
+                FlightSQLProtobuf.ACTION_BEGIN_TRANSACTION_RESULT_TYPE_URL
+            )
             any_message.value = result.SerializeToString()
-            
+
             serialized = any_message.SerializeToString()
-            logger.debug(f"Created ActionBeginTransactionResult using generated class: {serialized.hex()}")
+            logger.debug(
+                f"Created ActionBeginTransactionResult using generated class: {serialized.hex()}"
+            )
             return serialized
         except Exception as e:
             logger.error(f"Error creating ActionBeginTransactionResult: {e}")
-            return transaction_id.encode('utf-8')
+            return transaction_id.encode("utf-8")
 
     @staticmethod
     def get_type_mapping():
         """Get mapping from database types to Arrow types, matching Examples implementation."""
         return {
             # Numeric types
-            'INTEGER': pa.int32(),
-            'BIGINT': pa.int64(),
-            'SMALLINT': pa.int16(),
-            'TINYINT': pa.int8(),
-            'HUGEINT': pa.decimal128(38, 0),
-            'DECIMAL': pa.decimal128(38, 10),  # Default precision/scale
-            'FLOAT': pa.float32(),
-            'REAL': pa.float32(),
-            'DOUBLE': pa.float64(),
-            
+            "INTEGER": pa.int32(),
+            "BIGINT": pa.int64(),
+            "SMALLINT": pa.int16(),
+            "TINYINT": pa.int8(),
+            "HUGEINT": pa.decimal128(38, 0),
+            "DECIMAL": pa.decimal128(38, 10),  # Default precision/scale
+            "FLOAT": pa.float32(),
+            "REAL": pa.float32(),
+            "DOUBLE": pa.float64(),
             # String types
-            'VARCHAR': pa.string(),
-            'CHAR': pa.string(),
-            'TEXT': pa.string(),
-            'STRING': pa.string(),
-            'BLOB': pa.binary(),
-            
+            "VARCHAR": pa.string(),
+            "CHAR": pa.string(),
+            "TEXT": pa.string(),
+            "STRING": pa.string(),
+            "BLOB": pa.binary(),
             # Boolean
-            'BOOLEAN': pa.bool_(),
-            'BOOL': pa.bool_(),
-            
+            "BOOLEAN": pa.bool_(),
+            "BOOL": pa.bool_(),
             # Date/Time types
-            'DATE': pa.date32(),
-            'TIME': pa.time64('us'),
-            'TIMESTAMP': pa.timestamp('us'),
-            'TIMESTAMP_MS': pa.timestamp('ms'),
-            'TIMESTAMP_NS': pa.timestamp('ns'),
-            'TIMESTAMP_S': pa.timestamp('s'),
-            'INTERVAL': pa.duration('us'),
-            
+            "DATE": pa.date32(),
+            "TIME": pa.time64("us"),
+            "TIMESTAMP": pa.timestamp("us"),
+            "TIMESTAMP_MS": pa.timestamp("ms"),
+            "TIMESTAMP_NS": pa.timestamp("ns"),
+            "TIMESTAMP_S": pa.timestamp("s"),
+            "INTERVAL": pa.duration("us"),
             # Unsigned types
-            'UINTEGER': pa.uint32(),
-            'UBIGINT': pa.uint64(),
-            'USMALLINT': pa.uint16(),
-            'UTINYINT': pa.uint8(),
-            
+            "UINTEGER": pa.uint32(),
+            "UBIGINT": pa.uint64(),
+            "USMALLINT": pa.uint16(),
+            "UTINYINT": pa.uint8(),
             # Special types
-            'UUID': pa.string(),  # UUID as string
-            'JSON': pa.string(),  # JSON as string
-            
+            "UUID": pa.string(),  # UUID as string
+            "JSON": pa.string(),  # JSON as string
             # Default
-            'UNKNOWN': pa.null(),
+            "UNKNOWN": pa.null(),
         }
 
 
 # Transaction Action Request/Result classes
 class ActionBeginTransactionResult:
     """Result of beginning a transaction."""
+
     def __init__(self, transaction_id: bytes):
         self.transaction_id = transaction_id
 
+
 class EndTransaction:
     """Enum for transaction end actions."""
+
     UNSPECIFIED = 0
     COMMIT = 1
     ROLLBACK = 2
 
+
 class ActionBeginSavepointRequest:
     """Request to begin a savepoint."""
+
     def __init__(self, transaction_id: bytes, name: str):
         self.transaction_id = transaction_id
         self.name = name
 
+
 class ActionBeginSavepointResult:
     """Result of beginning a savepoint."""
+
     def __init__(self, savepoint_id: bytes):
         self.savepoint_id = savepoint_id
 
+
 class ActionEndSavepointRequest:
     """Request to end a savepoint."""
+
     def __init__(self, savepoint_id: bytes, action: int):
         self.savepoint_id = savepoint_id
         self.action = action
 
+
 class EndSavepoint:
     """Enum for savepoint end actions."""
+
     UNSPECIFIED = 0
     RELEASE = 1
     ROLLBACK = 2

--- a/uv.lock
+++ b/uv.lock
@@ -215,6 +215,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +346,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/b6/98f832e7a6c49aa3a464760c67c7856363aa644f2f3c74cf7d624168607e/black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e", size = 1765963, upload-time = "2025-01-29T04:18:38.116Z" },
     { url = "https://files.pythonhosted.org/packages/ce/e9/2cb0a017eb7024f70e0d2e9bdb8c5a5b078c5740c7f8816065d06f04c557/black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355", size = 1419419, upload-time = "2025-01-29T04:18:30.191Z" },
     { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/75/45438d368f799a73d3ff4172606847d1c94c008286a5537e92711e0e00a7/boto3-1.40.5.tar.gz", hash = "sha256:7340706beffe93e3638adcd77cb266f46ba424f77623a5a6be591baa3cdbd3f3", size = 111989, upload-time = "2025-08-07T19:31:42.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/a1/d6ab54adbe92e4ef4f38875776ff2fbd041a22a53d6a3235c5c6ccfc176f/boto3-1.40.5-py3-none-any.whl", hash = "sha256:8072f11a973709b582ef9834794721d543869cc506d029477172054dcc19c2da", size = 140061, upload-time = "2025-08-07T19:31:40.716Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/e5/8ac5229749f53fc47d0234aa6a583ce2d18b06f05cd46945977c2a1d25e9/botocore-1.40.5.tar.gz", hash = "sha256:f0c95e35a3a96a2b33d257160cbee923ae87b14ac3ba10f010f3baf8e03f73a2", size = 14315188, upload-time = "2025-08-07T19:31:30.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/2f/16db4ac90c0a60b8763724422d833d097c1276a249d619b5788e03ad2c3d/botocore-1.40.5-py3-none-any.whl", hash = "sha256:fbad8ce6605d45d12b9efbdcc9bbf68bcc5acc1ae3eb7dabb5919f38feeeeef7", size = 13975244, upload-time = "2025-08-07T19:31:25.044Z" },
 ]
 
 [[package]]
@@ -721,6 +759,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1041,6 +1088,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
 name = "logfire"
 version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1103,6 +1159,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "rich" },
+    { name = "snowflake" },
     { name = "typer" },
 ]
 
@@ -1147,6 +1204,7 @@ requires-dist = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "snowflake", specifier = ">=1.7.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev"]
@@ -1885,6 +1943,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/28/2659c02301b9500751f8d42f9a6632e1508aa5120de5e43042b8b30f8d5d/pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab", size = 56771, upload-time = "2025-05-17T16:28:29.197Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1928,6 +1999,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777, upload-time = "2024-08-06T20:33:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318, upload-time = "2024-08-06T20:33:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891, upload-time = "2024-08-06T20:33:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614, upload-time = "2024-08-06T20:33:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360, upload-time = "2024-08-06T20:33:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006, upload-time = "2024-08-06T20:33:37.501Z" },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577, upload-time = "2024-08-06T20:33:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593, upload-time = "2024-08-06T20:33:46.63Z" },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312, upload-time = "2024-08-06T20:33:49.073Z" },
 ]
 
 [[package]]
@@ -1986,6 +2131,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/05/d52bf1e65044b4e5e27d4e63e8d1579dbdec54fce685908ae09bc3720030/s3transfer-0.13.1.tar.gz", hash = "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf", size = 150589, upload-time = "2025-07-18T19:22:42.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724", size = 85308, upload-time = "2025-07-18T19:22:40.947Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2010,6 +2167,109 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snowflake"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "snowflake-core" },
+    { name = "snowflake-legacy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/f8/913dfda622ba237f846ef8aec6f8a3610d02f77604a162b54170d19ce2bc/snowflake-1.7.0.tar.gz", hash = "sha256:3917640958f61895a0e542cb17d09b942864d395a13a712cb09b3099ab5b5e29", size = 6039, upload-time = "2025-08-01T09:57:52.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/a8/161e3ddad928f13acf3afa2ab3592ef40e041a4d9276bef3dd2b43839a3c/snowflake-1.7.0-py3-none-any.whl", hash = "sha256:ce6c88fd0d589b1f0452754fca5d2ee81dc5613d9734a951bbff6d8e1f1e04fe", size = 5634, upload-time = "2025-08-01T09:57:51.577Z" },
+]
+
+[[package]]
+name = "snowflake-connector-python"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "sortedcontainers" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/31/b80afde8830afef0871dbcb4912545f326958c4d2ce36187c668fecb1913/snowflake_connector_python-3.16.0.tar.gz", hash = "sha256:88ca9438cc44cbd0bc078ecdf3273bd25bb69e3255c0416647281c5b2f490bb5", size = 779782, upload-time = "2025-07-01T23:58:23.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/6f/d7f3f75424a5e594a5fc5b201908df1bfa69243550802bf9af7b2fa52040/snowflake_connector_python-3.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:40928f889159e9af4d3057688bbb73559b1b67b104ebe6ee55cb2e727df52dab", size = 993097, upload-time = "2025-07-01T23:58:25.571Z" },
+    { url = "https://files.pythonhosted.org/packages/80/11/d44b0681a0b8a060a87211c59fe4070be307e2c5443e35450a58f024b019/snowflake_connector_python-3.16.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:fbfe84ffb69a94793481c6f26695a65ca07010f37866d086677f4addda78594b", size = 1005698, upload-time = "2025-07-01T23:58:27.187Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bb/33dc75ee0ebf948436b1a7e20a359f3aabc3b8f415cb98e9ebfe9cce728f/snowflake_connector_python-3.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:675d1d87154521e45c914aea5cfa48674338411c72a89dc3fd06075f8424f795", size = 2618897, upload-time = "2025-07-01T23:58:06.043Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b7/32ad953cadf11a082cfe2f5f40aa8a3bd1dfb09d9f625b627c61a67483e4/snowflake_connector_python-3.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38a49468a3746078dbcc7afeb708e83031e11beb4a2681ac786a57ebee232b78", size = 2641035, upload-time = "2025-07-01T23:58:08.775Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f1/674b5d5dd58917098ab112be30ec583f92fc5540c83583920eccad3390ed/snowflake_connector_python-3.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:2aad699a82278ea1f61570ff89650315b82bed71cc84ba8c1d8229af06100332", size = 951648, upload-time = "2025-07-01T23:58:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/40/2b5d1df656564f53952c94f176db5362c3dd8f1cffd00695235df57bf44e/snowflake_connector_python-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab3e19123b60305347b3486566000a0a05ac4540e6e5eaf8e31a03b6c6de0132", size = 993304, upload-time = "2025-07-01T23:58:28.511Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/9276ed9be967f1b5e926c31fd92138366a2d7110d5713ce5b351095034a4/snowflake_connector_python-3.16.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:9a153cb2ec837381cdeb4ac94c99d18aabfb495a5afe4769477b4b456cbd8c1a", size = 1005637, upload-time = "2025-07-01T23:58:29.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c4/1314043eb41794391f8398190c01e1197d0d3042c7f6c159ba1318d0dcec/snowflake_connector_python-3.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4db863e23edbc1439b3f09ff682abdd551b45c12e1c44a969a7631fefa5e87ee", size = 2632106, upload-time = "2025-07-01T23:58:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/f36774bc03be5d892c5241d790c34d458253c9a3ae6943b649c84c3fc813/snowflake_connector_python-3.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c555263c61fd126eb8a795034dcf5e56df42e2e7b3cdf0823f6e61eae425ef65", size = 2653236, upload-time = "2025-07-01T23:58:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/11/e70896521ff209969fbe75d0811182f9b59ab84b00951aaa4d2a4b5854a2/snowflake_connector_python-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd8f5f20066ccc140911ba96c77825cbcb1c2b59c189eab561f616e75d59c831", size = 951746, upload-time = "2025-07-01T23:58:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ce/2b4799464b76b36c9f8148fed51abc7c1cc2b92360130807e8ba150dcad2/snowflake_connector_python-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1943f3d682a516ef1217ffb137e583d4c4a200f286cc77ef8a8a53cb04b0a727", size = 992346, upload-time = "2025-07-01T23:58:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ea/100b3fa7a9fad4544013c49e34ba918f6ad0a43d8c184ea9f6a28995599c/snowflake_connector_python-3.16.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:9067363257a55bc020df956a5977237c7e1ea5bfbee3d0f2b1037c370eed0331", size = 1003984, upload-time = "2025-07-01T23:58:32.705Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/fd/2678f518e47b4cd22b3e4e9f15121d15ef08d3efdca8860f1535cecc4b22/snowflake_connector_python-3.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5af8c6294a70c12d883b56261e79b2a9b7e8318df4b2671adfc0ecc593f71fce", size = 2652814, upload-time = "2025-07-01T23:58:13.951Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/7d37bdff77b1419e95280f2c1f39f77fb4f3d449790acb032296eb698807/snowflake_connector_python-3.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c919abb9dc67f3ed3ca82c396a666760a4a3eefdc33947e3fa8fd4d4aafd796", size = 2676671, upload-time = "2025-07-01T23:58:15.225Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c0/c02ed21e1fb46a481b656dac58b7c60644ad57745ba2a46cc8cd172944d7/snowflake_connector_python-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:f4a5ba8ffa1bfcaf6f4bca41115711dcc938783e1f4e93ba6a155d07caa43e19", size = 950687, upload-time = "2025-07-01T23:58:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/52/90/941f75e97cbea26f5cb90bce9a1fd8e3315de98460bdd6a5a9bf43048994/snowflake_connector_python-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0a165e6a29c44bdeee5b23cbec0880fa23e7f099257737e292dce5d678a08c4", size = 993289, upload-time = "2025-07-01T23:58:33.925Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/52/f356d2ddd56d595883a9fd91da99632535d7ae6d8b82ea55a8605d60c33c/snowflake_connector_python-3.16.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:136ea110211958a3748c0e562051d25bd87b3aa58948cdc0816dfdf08afbb8fc", size = 1004683, upload-time = "2025-07-01T23:58:35.703Z" },
+    { url = "https://files.pythonhosted.org/packages/84/19/856c19da0fb001bf4fd46a239ab33cd8b03ec4651d482cfa1354f1966945/snowflake_connector_python-3.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e861b3d6abfe927639554cb81ff2c70bc12691e8ac9a2919b863e805c6caf8", size = 2655306, upload-time = "2025-07-01T23:58:16.81Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ed/90cc1776d3b5c9eb8f7c4e0203c3aa6cc9199920e30c53b937b5ff159774/snowflake_connector_python-3.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6474a2617c609461cbfa4122862aec1ba12ece2bb16505032dad4457d38e13b9", size = 2678862, upload-time = "2025-07-01T23:58:18.483Z" },
+    { url = "https://files.pythonhosted.org/packages/87/6a/dcad484e2a6bcd26fe641659f2f09f598068cedc0a351cb09fc0a9939e30/snowflake_connector_python-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:bab36467b6a9f696ae9fbae35d733557724d70ab779d89fe430844e876ce02c6", size = 950736, upload-time = "2025-07-01T23:58:44.74Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e1/7aff4cbc2dddc357509b293c16fc5a73a9f81193f36a86b8551b12131efe/snowflake_connector_python-3.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25be551a8ddc2404aed58509d4bca198bef83bf9ad8b1bb5a16e112eb2d4125d", size = 993633, upload-time = "2025-07-01T23:58:36.907Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/2ba05ce6d8376829e40396ea797048d09df201f6ac3d67beb897e96bcb07/snowflake_connector_python-3.16.0-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:0b692cd86ad5850d29931c1b16ea0bb0de8501d83f6edb420f62a6e1f933226e", size = 1006332, upload-time = "2025-07-01T23:58:38.222Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/470125297e5e18c81eee36828ac9232df70be052e91378773525f6de1530/snowflake_connector_python-3.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ace2e78f5b6bd3c8882aafdc7d21188b070fa335044f5068a46397cef439efe2", size = 2617138, upload-time = "2025-07-01T23:58:20.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1a/ba46d634ec5a30922558e39e2573094aaae73cda7f0da16c828b371300b8/snowflake_connector_python-3.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58741dadcec59dbd07654ecf8087fb0a74f5e16a9cc9c24f42a52658539dff01", size = 2639184, upload-time = "2025-07-01T23:58:21.983Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/7567e781f413ba70cd1d54e376372fbfd2a602ce805f28e88fd2a87cb5e6/snowflake_connector_python-3.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:a0b94d35631779086895e28bdb145888a8bab4786b840b3f557960b91c9fa05a", size = 952440, upload-time = "2025-07-01T23:58:46.387Z" },
+]
+
+[[package]]
+name = "snowflake-core"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "snowflake-connector-python" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/72/3daea26f941512e2a2d18eda62eb2fc67ffc1be33027b1e74f4c4430a2e2/snowflake_core-1.7.0.tar.gz", hash = "sha256:8655a94c211ae04d1d803dbc876249de6d3f8021cc5738d689aea842d1b66a7f", size = 1314443, upload-time = "2025-08-01T09:57:52.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/40/a08e639e8215a8c8832befb0d30266c465000adebb9eab7d8eb608361255/snowflake_core-1.7.0-py3-none-any.whl", hash = "sha256:f67340f2d2baafd03b34e24b07bf67f7844f09dfb05d0ad22ea1818cfa7b35d4", size = 1949343, upload-time = "2025-08-01T09:57:49.847Z" },
+]
+
+[[package]]
+name = "snowflake-legacy"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/08/1c22d84aacfce90a13ce23b6bc7ca0ab6d85146e559558d05ff24b5df89a/snowflake_legacy-1.0.1.tar.gz", hash = "sha256:98f7d2b19128c53a20eb25731ba62849bbb2747c33a0ea54f340d0feac9d4bb0", size = 4059, upload-time = "2025-06-10T10:22:48.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/37/5ab1b50a62b9063f1e00322ea1982848a01638e4efd32c9f03bb387ee170/snowflake_legacy-1.0.1-py3-none-any.whl", hash = "sha256:36135aef966231d291c10ceddb27c7021e9b8d960f73bdc4eccdf02ffc5b90c7", size = 3059, upload-time = "2025-06-10T10:22:47.49Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -2049,6 +2309,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Derives table name from descriptor.path.
Uses backend to fetch schema and row count.
Returns FlightInfo with a PATH ticket, supports both CMD and PATH. do_put: New PATH branch
Requires reader.schema; creates table, appends all incoming batches. Acknowledges completion (writes empty metadata best‑effort). protobuf.py
parse_any_command: Returns None when bytes are empty (PATH case) and logs the event.