### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Copilot Setup Steps"
 on: workflow_dispatch
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/MiguelElGallo/mpzsql/security/code-scanning/5](https://github.com/MiguelElGallo/mpzsql/security/code-scanning/5)

To fix the problem, we should add a `permissions` block to the workflow or to the specific job. Since the workflow does not appear to require write access to repository contents or other resources, the minimal starting point is to set `contents: read`. This should be added either at the root of the workflow (to apply to all jobs) or under the specific job (`copilot-setup-steps`). The best practice is to add it at the root unless a job requires different permissions. The change should be made at the top level of `.github/workflows/copilot-setup-steps.yml`, immediately after the `name` and before `on` or `jobs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
