### PR TITLE
Make code simplifier manual only

### DIFF
--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -34,9 +34,6 @@
 
 name: "Code Simplifier"
 "on":
-  schedule:
-  - cron: "25 13 * * *"
-    # Friendly format: daily (scattered)
   # skip-if-match: is:pr is:open in:title "[code-simplifier]" # Skip-if-match processed as search check in pre-activation job
   workflow_dispatch:
 
@@ -1245,4 +1242,3 @@ jobs:
           name: safe-output-items
           path: /tmp/safe-output-items.jsonl
           if-no-files-found: warn
-

--- a/.github/workflows/code-simplifier.md
+++ b/.github/workflows/code-simplifier.md
@@ -2,7 +2,7 @@
 name: Code Simplifier
 description: Analyzes recently modified code and creates pull requests with simplifications that improve clarity, consistency, and maintainability while preserving functionality
 on:
-  schedule: daily
+  workflow_dispatch:
   skip-if-match: 'is:pr is:open in:title "[code-simplifier]"'
 
 permissions:


### PR DESCRIPTION
This pull request updates the configuration for the Code Simplifier workflow by removing its scheduled daily runs and making it triggerable only via manual dispatch. This change affects both the workflow's YAML and Markdown configuration files.

**Workflow Trigger Changes:**

* [`.github/workflows/code-simplifier.lock.yml`](diffhunk://#diff-660b7e677298e64ae1aa244981e61e61af2ff42ea7f18da03676b83549f09a47L37-L39): Removed the scheduled cron job so the workflow will no longer run automatically each day; it can now only be started manually via `workflow_dispatch`.
* [`.github/workflows/code-simplifier.md`](diffhunk://#diff-ed2a1fbfd01c5775ff0fea27cf2a9710d57561d264c49fa3614d88938849bcadL5-R5): Updated the documentation to reflect the removal of the daily schedule in favor of manual dispatch.

**Minor Cleanup:**

* [`.github/workflows/code-simplifier.lock.yml`](diffhunk://#diff-660b7e677298e64ae1aa244981e61e61af2ff42ea7f18da03676b83549f09a47L1248): Removed an unnecessary trailing line in the `jobs` section for tidiness.